### PR TITLE
Remove on push trigger for my-main branch

### DIFF
--- a/.github/workflows/fortify-fod.yml
+++ b/.github/workflows/fortify-fod.yml
@@ -7,7 +7,7 @@ name: Fortify on Demand - SAST
 
 on:
   push:
-    branches: [ 'my-main', 'feat/*' ]
+    branches: [ 'feat/*' ]
   pull_request:
     branches: [ my-main ]
   workflow_dispatch:

--- a/.github/workflows/fortify-scsast-remote-translate.yml
+++ b/.github/workflows/fortify-scsast-remote-translate.yml
@@ -8,7 +8,7 @@ name: Fortify SC SAST - Remote Translate
 
 on:
   push:
-    branches: [ 'my-main', 'feat/*' ]
+    branches: [ 'feat/*' ]
   pull_request:
     branches: [ my-main ]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- remove on push trigger for my-main branch in fortify-scsast-remote-translate workflow
- retain existing scheduled/manual triggers

## Testing
- not run (workflow change only)