### PR TITLE
chore: Remove on push trigger for feat branch

### DIFF
--- a/.github/workflows/fortify-fod.yml
+++ b/.github/workflows/fortify-fod.yml
@@ -10,8 +10,6 @@ permissions:
   security-events: write
 
 on:
-  push:
-    branches: [ 'feat/*' ]
   pull_request:
     branches: [ my-main ]
   workflow_dispatch:

--- a/.github/workflows/fortify-scsast-remote-translate.yml
+++ b/.github/workflows/fortify-scsast-remote-translate.yml
@@ -11,8 +11,6 @@ permissions:
   security-events: write
 
 on:
-  push:
-    branches: [ 'feat/*' ]
   pull_request:
     branches: [ my-main ]
   workflow_dispatch:

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -15,8 +15,6 @@ permissions:
   security-events: write
 
 on:
-  push:
-    branches: [ 'feat/*' ]
   pull_request:
     branches: [ my-main ]
   workflow_dispatch:


### PR DESCRIPTION
## Description
Removes the `on: push` trigger from feature branch workflows to reduce noise when testing individual workflows.

## Motivation
When testing or developing a single workflow, having multiple workflows trigger on every push creates excessive noise and consumes unnecessary CI/CD resources.

## Changes
- Removed `on: push` trigger from fortify-fod.yml
- Removed `on: push` trigger from fortify-scsast-remote-translate.yml
- Removed `on: push` trigger from sonatype.yml